### PR TITLE
set omitempty for non-required Tag fields.

### DIFF
--- a/jcapi-tags.go
+++ b/jcapi-tags.go
@@ -17,13 +17,13 @@ type JCTagResults struct {
 type JCTag struct {
 	Id                 string   `json:"_id,omitempty"`
 	Name               string   `json:"name"`
-	GroupName          string   `json:"groupname"`
-	Systems            []string `json:"systems"`
-	SystemUsers        []string `json:"systemusers"`
-	RegularExpressions []string `json:"regularExpressions"`
-	ExpirationTime     string   `json:"expirationTime"`
-	Expired            bool     `json:"expired"`
-	Selected           bool     `json:"selected"`
+	GroupName          string   `json:"groupname,omitempty"`
+	Systems            []string `json:"systems,omitempty"`
+	SystemUsers        []string `json:"systemusers,omitempty"`
+	RegularExpressions []string `json:"regularExpressions,omitempty"`
+	ExpirationTime     string   `json:"expirationTime,omitempty"`
+	Expired            bool     `json:"expired,omitempty"`
+	Selected           bool     `json:"selected,omitempty"`
 
 	//
 	// For identification as an external user directory source


### PR DESCRIPTION
These changes are required for the Tag support that I've pushed to jumpcloud-terraform-provider.